### PR TITLE
Added jumpBetweenOpeningAndClosingSymbols command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.4.0]
+  Added new hotkey action to jump between opening and closing symbols.  
+  Special thanks to [@Kotsuha](https://github.com/Kotsuha) for implementing this.
+
 ## [2.3.2]
   Fixed issue where the backwards search would incorrectly highlight text.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This extension provides several hotkeys to work with highlighted symbols.
 * `BracketHighlighter.jumpToClosingSymbol`: Jumps to the inside of the closing symbol. (Default hotkey: Ctrl + Alt + RightArrow)
 * `BracketHighlighter.jumpToOpeningSymbol`: Jumps to the inside of the opening symbol. (Default hotkey: Ctrl + Alt + LeftArrow)
 * `BracketHighlighter.selectTextInSymbols`: Selects the whole text between (and not including) the symbols. (Default hotkey: Ctrl + Alt + K)
+* `BracketHighlighter.jumpBetweenOpeningAndClosingSymbols`: Jumps between the opening and closing symbols. (Default hotkey: Ctrl + Alt + \\)
 
 
 Refer to https://www.w3schools.com/cssref/ for all CSS options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "brackethighlighter",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "brackethighlighter",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"minimist": "^1.2.6"
@@ -18,7 +18,7 @@
 				"@types/vscode": "^1.40.0",
 				"glob": "^7.1.4",
 				"tslint": "^5.12.1",
-				"typescript": "^3.9.9",
+				"typescript": "^4.0.0",
 				"vscode-test": "^1.0.2"
 			},
 			"engines": {
@@ -725,9 +725,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -1349,9 +1349,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true
 		},
 		"unzipper": {

--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
 		"@types/vscode": "^1.40.0",
 		"glob": "^7.1.4",
 		"tslint": "^5.12.1",
-		"typescript": "^3.9.9",
+		"typescript": "^4.0.0",
 		"vscode-test": "^1.0.2"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"readme": "README.md",
 	"license": "SEE LICENSE IN LICENSE",
 	"description": "Decorates text inbetween symbols.",
-	"version": "2.3.2",
+	"version": "2.4.0",
 	"engines": {
 		"vscode": "^1.40.0"
 	},

--- a/package.json
+++ b/package.json
@@ -261,6 +261,11 @@
 				"command": "BracketHighlighter.selectTextInSymbols",
 				"title": "Selects the whole text between symbols.",
 				"when": "editorTextFocus"
+			},
+			{
+				"command": "BracketHighlighter.jumpBetweenOpeningAndClosingSymbols",
+				"title": "Jump between opening and closing symbols.",
+				"when": "editorTextFocus"
 			}
 		],
 		"keybindings": [
@@ -292,6 +297,11 @@
 			{
 				"command": "BracketHighlighter.selectTextInSymbols",
 				"key": "ctrl+alt+k",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "BracketHighlighter.jumpBetweenOpeningAndClosingSymbols",
+				"key": "ctrl+alt+\\",
 				"when": "editorTextFocus"
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -224,6 +224,20 @@
 						"default": false,
 						"description": "If enabled, escaped symbols will be ignored.",
 						"scope": "resource"
+					},
+					"BracketHighlighter.defaultJumpBetweenStrategy": {
+						"type": "string",
+						"description": "Specify the default strategy to be used to jump between opening and closing symbols.",
+						"enum": [
+							"toSymbolStart",
+							"toSymbolOppositeSide"
+						],
+						"enumDescriptions": [
+							"Jump to the start of a symbol. This is the same as VS Code's default \"Go to Bracket\" (Ctrl+Shift+\\) behavior.",
+							"Jump to the opposite side of a symbol."
+						],
+						"default": "toSymbolStart",
+						"scope": "resource"
 					}
 				}
 			}

--- a/src/ActionHandler.ts
+++ b/src/ActionHandler.ts
@@ -13,7 +13,7 @@ export default class HotkeyHandler {
 
     public onJumpOutOfOpeningSymbolHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
         let newSelectionPositions = this.getOpeningSymbolOutsideSelectionPositions();
@@ -22,7 +22,7 @@ export default class HotkeyHandler {
 
     public onJumpOutOfClosingSymbolHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
         let newSelectionPositions = this.getClosingSymbolOutsideSelectionPositions();
@@ -31,7 +31,7 @@ export default class HotkeyHandler {
 
     public onJumpToOpeningSymbolHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
         let newSelectionPositions = this.getOpeningSymbolInsideSelectionPositions();
@@ -39,17 +39,16 @@ export default class HotkeyHandler {
     }
     public onJumpToClosingSymbolHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
         let newSelectionPositions = this.getClosingSymbolInsideSelectionPositions();
         this.setSelectionPositions(activeEditor, newSelectionPositions);
     }
 
-    public onjumpBetweenOpeningAndClosingSymbolsHotkey()
-    {
+    public onjumpBetweenOpeningAndClosingSymbolsHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
 
@@ -78,7 +77,7 @@ export default class HotkeyHandler {
 
     public onSelectTextBetweenSymbolsHotkey() {
         let activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
+        if (!activeEditor || bracketHighlightGlobals.highlightRanges.length <= 0) {
             return;
         }
         let selectionRanges: vscode.Range[] = [];
@@ -129,7 +128,7 @@ export default class HotkeyHandler {
     private getClosingSymbolInsideSelectionPositions(): vscode.Position[] {
         let newSelectionPositions: vscode.Position[] = [];
         let activeEditor = vscode.window.activeTextEditor;
-        if (activeEditor) {
+        if (activeEditor && bracketHighlightGlobals.highlightRanges.length > 0) {
             for (let index = 0; index < bracketHighlightGlobals.highlightRanges.length; index++) {
                 let range = bracketHighlightGlobals.highlightRanges[index];
                 let symbol = this.getStartSymbol(index);
@@ -185,11 +184,6 @@ export default class HotkeyHandler {
     private getStartSymbol(index: number): string {
         return bracketHighlightGlobals.highlightSymbols[index];
     }
-
-    private getEndSymbol(index: number): string {
-        return bracketHighlightGlobals.highlightSymbols[index];
-    }
-
 }
 
 export { HotkeyHandler };

--- a/src/ActionHandler.ts
+++ b/src/ActionHandler.ts
@@ -78,8 +78,8 @@ export default class HotkeyHandler {
 
         const symbolRangePairs: SymbolRangePair[] = [];
         for (let i = 0; i < openingOutsideSelectionPositions.length; i++) {
-            const openingSymbolRange = new vscode.Range(openingOutsideSelectionPositions[i], openingInsideSelectionPositions[i]); 
-            const closingSymbolRange = new vscode.Range(closingInsideSelectionPositions[i], closingOutsideSelectionPositions[i]); 
+            const openingSymbolRange = new vscode.Range(openingOutsideSelectionPositions[i], openingInsideSelectionPositions[i]);
+            const closingSymbolRange = new vscode.Range(closingInsideSelectionPositions[i], closingOutsideSelectionPositions[i]);
             const symbolRangePair: SymbolRangePair = [openingSymbolRange, closingSymbolRange];
             symbolRangePairs.push(symbolRangePair);
         }
@@ -234,9 +234,11 @@ export default class HotkeyHandler {
         for (let i = 0; i < newPositions.length; i++) {
             newSelections.push(new vscode.Selection(newPositions[i], newPositions[i]));
         }
-        activeEditor.selections = newSelections;
-        if (revealRange) {
-            activeEditor.revealRange(activeEditor.selections[0]);
+        if (newSelections.length > 0) {
+            activeEditor.selections = newSelections;
+            if (revealRange) {
+                activeEditor.revealRange(activeEditor.selections[0]);
+            }
         }
     }
 

--- a/src/ConfigHandler.ts
+++ b/src/ConfigHandler.ts
@@ -95,7 +95,7 @@ export default class ConfigHandler {
     private isDifferentSymbolHighlightingUsed(): boolean {
         const config = this.getConfiguration();
         let differentHighlightingUsed: boolean | undefined = config.get("differentSymbolHighlightingUsed");
-        if(!differentHighlightingUsed) {
+        if (!differentHighlightingUsed) {
             differentHighlightingUsed = false;
         }
         return differentHighlightingUsed;
@@ -250,15 +250,16 @@ export default class ConfigHandler {
         let config = this.getConfiguration();
         let strategy: JumpBetweenStrategy;
         let strategyStr: string | undefined = config.get("defaultJumpBetweenStrategy");
+        let defaultStrategy: JumpBetweenStrategy = JumpBetweenStrategy.TO_SYMBOL_START;
         if (strategyStr === undefined) {
-            strategy = JumpBetweenStrategy.TO_SYMBOL_START;
+            strategy = defaultStrategy;
         }
         else {
             const allStrategies = Object.values(JumpBetweenStrategy);
             strategy = strategyStr as JumpBetweenStrategy;
             const isValidStrategy = allStrategies.indexOf(strategy) >= 0;
             if (!isValidStrategy) {
-                strategy = JumpBetweenStrategy.TO_SYMBOL_START;
+                strategy = defaultStrategy;
             }
         }
         return strategy;

--- a/src/GlobalsHandler.ts
+++ b/src/GlobalsHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { DecorationType } from './DecorationHandler';
 import DecorationOptions from './DecorationOptions';
-import ConfigHandler from './ConfigHandler';
+import { ConfigHandler, JumpBetweenStrategy } from './ConfigHandler';
 
 const enum SearchDirection {
     FORWARDS,
@@ -38,6 +38,8 @@ export default class GlobalsHandler {
     public timeOutValue!: number;
     public ignoreContent!: boolean;
     public regexMode!: boolean;
+    public defaultJumpBetweenStrategy!: JumpBetweenStrategy;
+    public preferredJumpBetweenStrategiesBySymbol!: Map<string, JumpBetweenStrategy>;
 
 
     constructor() {
@@ -71,6 +73,8 @@ export default class GlobalsHandler {
         this.timeOutValue = this.configHandler.getTimeOutValue();
         this.ignoreContent = this.configHandler.ignoreContent();
         this.regexMode = this.configHandler.regexMode();
+        this.defaultJumpBetweenStrategy = this.configHandler.defaultJumpBetweenStrategy();
+        this.preferredJumpBetweenStrategiesBySymbol = this.configHandler.preferredJumpBetweenStrategiesBySymbol();
 
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,9 +102,6 @@ function handleTextSelectionEvent() {
 	for (let selection of activeEditor.selections) {
 		let symbolType: Util.SymbolType = bracketHighlightGlobals.reverseSearchEnabled ? Util.SymbolType.ALLSYMBOLS : Util.SymbolType.STARTSYMBOL;
 		startSymbol = Util.getSymbolFromPosition(activeEditor, selection.active, symbolType);
-		if (startSymbol.symbol === '') {
-			return;
-		}
 		let scopeRanges = getScopeRanges(activeEditor, selection, startSymbol);
 		if (scopeRanges.highlightRanges.length === 0) {
 			return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,9 @@ export function activate(context: vscode.ExtensionContext) {
 	let onJumpToClosingSymbolDisposable = vscode.commands.registerCommand('BracketHighlighter.jumpToClosingSymbol', () => {
 		actionHandler.onJumpToClosingSymbolHotkey();
 	});
+	let onjumpBetweenOpeningAndClosingSymbolsDisposable = vscode.commands.registerCommand('BracketHighlighter.jumpBetweenOpeningAndClosingSymbols', () => {
+		actionHandler.onjumpBetweenOpeningAndClosingSymbolsHotkey();
+	});
 	let onSelectTextBetweenSymbols = vscode.commands.registerCommand('BracketHighlighter.selectTextInSymbols', () => {
 		actionHandler.onSelectTextBetweenSymbolsHotkey();
 	});
@@ -39,6 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(onJumpOutOfClosingSymbolDisposable);
 	context.subscriptions.push(onJumpToOpeningSymbolDisposable);
 	context.subscriptions.push(onJumpToClosingSymbolDisposable);
+	context.subscriptions.push(onjumpBetweenOpeningAndClosingSymbolsDisposable);
 	context.subscriptions.push(onSelectTextBetweenSymbols);
 }
 
@@ -98,6 +102,9 @@ function handleTextSelectionEvent() {
 	for (let selection of activeEditor.selections) {
 		let symbolType: Util.SymbolType = bracketHighlightGlobals.reverseSearchEnabled ? Util.SymbolType.ALLSYMBOLS : Util.SymbolType.STARTSYMBOL;
 		startSymbol = Util.getSymbolFromPosition(activeEditor, selection.active, symbolType);
+		if (startSymbol.symbol === '') {
+			return;
+		}
 		let scopeRanges = getScopeRanges(activeEditor, selection, startSymbol);
 		if (scopeRanges.highlightRanges.length === 0) {
 			return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,6 @@ function handleTextSelectionEvent() {
 		}
 		rangesForHighlight.push(scopeRanges.highlightRanges);
 		rangesForBlur.push(scopeRanges.blurRanges);
-		bracketHighlightGlobals.highlightSymbols.push(startSymbol.symbol);
 	}
 	let endSymbols = symbolHandler.getCounterParts(startSymbol.symbol);
 	let endSymbol = "";
@@ -194,7 +193,6 @@ function getScopeRanges(activeEditor: vscode.TextEditor, selection: vscode.Selec
 			currentIndex++;
 		}
 	}
-	bracketHighlightGlobals.highlightSymbols.push(startSymbol.symbol);
 	if (bracketHighlightGlobals.searchDirection === SearchDirection.BACKWARDS) {
 		selectionRange.selectionRange = selectionRange.selectionRange.reverse();
 	}
@@ -324,6 +322,8 @@ function handleHighlightRanges(activeEditor: vscode.TextEditor, textRanges: Arra
 	if (bracketHighlightGlobals.searchDirection === SearchDirection.BACKWARDS) {
 		[startSymbol, endSymbol] = [endSymbol, startSymbol];
 	}
+	
+	bracketHighlightGlobals.highlightSymbols.push(startSymbol);
 
 	contentRanges[0][0] = new vscode.Range(firstRange.start.translate(0, startSymbol.length), firstRange.end);
 	contentRanges[contentRanges.length - 1][contentRanges[contentRanges.length - 1].length - 1] = new vscode.Range(lastRange.start, lastRange.end.translate(0, -endSymbol.length));


### PR DESCRIPTION
I use VSCode's default shortcut `ctrl+shift+\`  to jump between opening and closing brackets. I work with C# so I want to jump between `#if` `#endif` `#region` `#endregion` as well. As far as I know VSCode doesn't support it.

This extension supports custom symbols and provides shortcuts to jump to opening and closing brackets, but it doesn't have a shortcut to jump between them like the default `ctrl+shift+\` do. I tried to add this feature in this commit.

![bracket-highlighter](https://github.com/Durzn/BracketHighlighter/assets/10438710/0c083c60-014c-4b7e-bccc-00a3561a2ca1)

Currently the highlighted part seems not correct, as you can see in the GIF. It seems to be an old bug.

Also I am not sure about the change I made in `src/extension.ts`.
```
		if (startSymbol.symbol === '') {
			return;
		}
```

Feel free to use this PR or not. Thank you for this extension :) I've been using it for a long time.